### PR TITLE
Release severity: non-security patch should be `notice`

### DIFF
--- a/src/VersionAnalyzer.php
+++ b/src/VersionAnalyzer.php
@@ -266,7 +266,7 @@ class VersionAnalyzer {
       return $releaseSeverity;
     }
     else {
-      $releaseSeverity = 'warning';
+      $releaseSeverity = 'notice';
       return $releaseSeverity;
     }
   }


### PR DESCRIPTION
When the new system for getting version severity was implemented, it increased the default severity of patch releases to `warning`.  Before, the [default severity was `notice`](https://github.com/civicrm/civicrm-core/commit/887903781c97c9ce6906642f456a57ae630df92a#diff-50f6e167c4bfdcf605b5e0617d06b82dL512).

This changes it back to `notice`.

In my mind @totten this is kind of urgent because users are now seeing "System Status: Warning" if they have 5.1.0 and thinking it's serious.  Also, sites that have hushed the upgrade message at a severity of `notice` will suddenly have the upgrade message pop up because it's higher severity.  If they hush it again, that will mean that actual `warning`-level messages are suppressed.