### PR TITLE
infrastructure/ops#871 having a month-old version should be a notice

### DIFF
--- a/src/Report/SummaryReport.php
+++ b/src/Report/SummaryReport.php
@@ -148,9 +148,11 @@ class SummaryReport {
       case 'deprecated':
         $result = [
           'name' => 'upgrade',
-          'severity' => 'warning',
-          'title' => E::ts('CiviCRM Upgrade Available'),
-          'message' => $this->createBranchList(),
+          'severity' => 'notice',
+          'title' => E::ts('New CiviCRM Version Available'),
+          'message' =>
+            _para(E::ts('CiviCRM {latestStableBranch} is now available, and CiviCRM {userBranch} will no longer receive bug fixes or security updates. You should plan to upgrade in the coming months.', $tsVars))
+            . $this->createBranchList(),
         ];
         break;
 


### PR DESCRIPTION
This responds to the concerns in [infrastructure/ops#871](https://lab.civicrm.org/infrastructure/ops/issues/871) where people are getting system check warnings because they're on 5.8.x, which is only a month old.

It's good that versions that are only a few months old, with no intervening security releases, are labeled `deprecated` rather than `eol`.  That makes the language less scary.  However, the severity of the system check was still `warning`.  That leaves no room for escalation when the version truly is too old.

Also, it really isn't that any worse to be on 5.8.2 than on 5.9.0, when 5.9.1 is the latest.  We know that 5.9.1 fixes bugs, but it may be fixing bugs introduced in 5.9.0, so someone on 5.8.2 could be just fine.  The only consideration is that the person on 5.8.2 is one month closer to end-of-life.

This change de-escalates the severity of a `deprecated` version to `notice`, and it modifies the status message to explain what it means to be on an older version.